### PR TITLE
Allow to disable recaptcha explicitly by env variable

### DIFF
--- a/services/recaptcha.go
+++ b/services/recaptcha.go
@@ -32,6 +32,9 @@ type recaptchaResponse struct {
 }
 
 func IsHuman(req *http.Request) bool {
+	if os.Getenv("GOOGLE_RECAPTCHA_DISABLED") != "" {
+		return true
+	}
 	req.ParseForm()
 	challenge := req.Form.Get("g-recaptcha-response")
 


### PR DESCRIPTION
The reason for this is because sometimes in dev enviroments recaptcha
might return a wrong answer, so it's nice to have a way to
explicitly disable it

@xetorthio @jpetazzo :bell: 