### PR TITLE
Develop on a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Prepares the virtual box instance
+prepare:
+	# Creates the virtual box
+	-docker-machine create -d virtualbox --virtualbox-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v1.13.0-rc1/boot2docker.iso pwd && true
+	# Makes sure the docker daemon has the DinD image pulled
+	-docker-machine ssh pwd "docker pull franela/pwd-1.12.3-experimental-dind"
+	# Daemon should be swarm
+	-docker-machine ssh pwd "docker swarm init --advertise-addr $$(docker-machine ip pwd)"
+	# Stops to daemon to do further configurations on the box
+	-docker-machine stop pwd
+	# Adds the host GOPATH as a shared folder in the box
+	-VBoxManage sharedfolder add pwd --name gopathsrc --hostpath ${GOPATH}src --automount
+	# Do port forwaring so we can reach the app using localhost:3000
+	-VBoxManage modifyvm pwd --natpf1 "nameformapping,tcp,,3000,,3000"
+
+# Starts the virtual box instance
+start:
+	# Starts the machine
+	-docker-machine start pwd
+	# Make sure the folder where we'll mount the shared folder exists
+	docker-machine ssh pwd "sudo mkdir -p /go/src"
+	# Mount the host's GOPATH shared folder
+	docker-machine ssh pwd "sudo mount -t vboxsf gopathsrc /go/src"
+
+# Runs the app
+run:
+	@eval $$(docker-machine env pwd); \
+	docker-compose up
+
+.PHONY: prepare start run

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ prepare:
 	# Adds the host GOPATH as a shared folder in the box
 	-VBoxManage sharedfolder add pwd --name gopathsrc --hostpath ${GOPATH}src --automount
 	# Do port forwaring so we can reach the app using localhost:3000
-	-VBoxManage modifyvm pwd --natpf1 "nameformapping,tcp,,3000,,3000"
+	-VBoxManage modifyvm pwd --natpf1 "localhost,tcp,,3000,,3000"
 
 # Starts the virtual box instance
 start:

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,5 @@ start:
 	# Mount the host's GOPATH shared folder
 	docker-machine ssh pwd "sudo mount -t vboxsf gopathsrc /go/src"
 
-# Runs the app
-run:
-	@eval $$(docker-machine env pwd); \
-	docker-compose up
 
 .PHONY: prepare start run

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ just run `docker swarm init`.
 It's also necessary to manually load the IPVS kernel module because as swarms are created in `dind`, 
 the daemon won't load it automatically. Run the following command for that purpose: `sudo lsmod xt_ipvs`
 
+If you are developing, there is a `Makefile` file with 2 targets that can set the whole environment for you (using docker-machine and virtual box).
+Just run once `make create`, which will create the docker-machine environment.
+Additionally, every time you want to start you environment run `make start`.
+And to start the application on a container on the docker machine host, run: `eval $(docker-machine env pwd) && docker-compose up`
+
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '2'
 services:
     web:
+        # pwd daemon container always needs to be named this way
+        container_name: pwd
         # use the latest golang image
         image: golang
         # go to the right place and starts the app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+    web:
+        # use the latest golang image
+        image: golang
+        # go to the right place and starts the app
+        command: /bin/sh -c 'cd /go/src/github.com/franela/play-with-docker; go run api.go'
+        ports:
+            # app exposes port 3000
+            - "3000:3000"
+        volumes:
+            # since this app creates networks and launches containers, we need to talk to docker daemon
+            - /var/run/docker.sock:/var/run/docker.sock
+            # mount the box mounted shared folder to the container
+            - /go/src:/go/src


### PR DESCRIPTION
Adds a Makefile to make the virtual box creation, start and app run reproducible.
This allows to develop PWD on a container, which is nice and also
necessary once "reverse proxy" feature is introduced.