### PR TITLE
Add reverse proxy endpoint.

### DIFF
--- a/api.go
+++ b/api.go
@@ -60,7 +60,8 @@ func main() {
 	r.Handle("/sessions/{sessionId}/ws/", server)
 
 	// Reverse proxy
-	r.Host(`{node}.{session}.play-with-docker.com`).Handler(handlers.NewMultipleHostReverseProxy())
+	r.Host(`{node}-{port:[0-9]*}.play-with-docker.com`).Handler(handlers.NewMultipleHostReverseProxy())
+	r.Host(`{node}.play-with-docker.com`).Handler(handlers.NewMultipleHostReverseProxy())
 
 	n := negroni.Classic()
 	n.UseHandler(r)

--- a/api.go
+++ b/api.go
@@ -60,8 +60,9 @@ func main() {
 	r.Handle("/sessions/{sessionId}/ws/", server)
 
 	// Reverse proxy
-	r.Host(`{node}-{port:[0-9]*}.play-with-docker.com`).Handler(handlers.NewMultipleHostReverseProxy())
-	r.Host(`{node}.play-with-docker.com`).Handler(handlers.NewMultipleHostReverseProxy())
+	proxyHandler := handlers.NewMultipleHostReverseProxy()
+	r.Host(`{node}-{port:[0-9]*}.play-with-docker.com`).Handler(proxyHandler)
+	r.Host(`{node}.play-with-docker.com`).Handler(proxyHandler)
 
 	n := negroni.Classic()
 	n.UseHandler(r)

--- a/api.go
+++ b/api.go
@@ -59,6 +59,9 @@ func main() {
 
 	r.Handle("/sessions/{sessionId}/ws/", server)
 
+	// Reverse proxy
+	r.Host(`{node}.{session}.play-with-docker.com`).Handler(handlers.NewMultipleHostReverseProxy())
+
 	n := negroni.Classic()
 	n.UseHandler(r)
 

--- a/api.go
+++ b/api.go
@@ -36,6 +36,12 @@ func main() {
 	}
 
 	r := mux.NewRouter()
+
+	// Reverse proxy (needs to be the first route, to make sure it is the first thing we check)
+	proxyHandler := handlers.NewMultipleHostReverseProxy()
+	r.Host(`{node:ip[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}}-{port:[0-9]*}.{tld:.*}`).Handler(proxyHandler)
+	r.Host(`{node:ip[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}}.{tld:.*}`).Handler(proxyHandler)
+
 	r.StrictSlash(false)
 
 	r.HandleFunc("/ping", http.HandlerFunc(handlers.Ping)).Methods("GET")
@@ -58,11 +64,6 @@ func main() {
 	}))
 
 	r.Handle("/sessions/{sessionId}/ws/", server)
-
-	// Reverse proxy
-	proxyHandler := handlers.NewMultipleHostReverseProxy()
-	r.Host(`{node}-{port:[0-9]*}.play-with-docker.com`).Handler(proxyHandler)
-	r.Host(`{node}.play-with-docker.com`).Handler(proxyHandler)
 
 	n := negroni.Classic()
 	n.UseHandler(r)

--- a/handlers/reverseproxy.go
+++ b/handlers/reverseproxy.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+func NewMultipleHostReverseProxy() *httputil.ReverseProxy {
+	director := func(req *http.Request) {
+		v := mux.Vars(req)
+		node := v["node"]
+		if strings.HasPrefix(node, "ip") {
+			// Node is actually an ip, need to convert underscores by dots.
+			ip := strings.Replace(strings.TrimPrefix(node, "ip"), "_", ".", -1)
+
+			if net.ParseIP(ip) == nil {
+				// Not a valid IP, so treat this is a hostname.
+			} else {
+				node = ip
+			}
+		}
+
+		// Validate that the node actually exists in the network
+		// TODO:
+
+		// Only proxy http for now
+		req.URL.Scheme = "http"
+
+		req.URL.Host = node
+	}
+
+	return &httputil.ReverseProxy{Director: director}
+}

--- a/handlers/reverseproxy.go
+++ b/handlers/reverseproxy.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -13,6 +14,10 @@ func NewMultipleHostReverseProxy() *httputil.ReverseProxy {
 	director := func(req *http.Request) {
 		v := mux.Vars(req)
 		node := v["node"]
+		port := v["port"]
+		if port == "" {
+			port = "80"
+		}
 		if strings.HasPrefix(node, "ip") {
 			// Node is actually an ip, need to convert underscores by dots.
 			ip := strings.Replace(strings.TrimPrefix(node, "ip"), "_", ".", -1)
@@ -24,13 +29,10 @@ func NewMultipleHostReverseProxy() *httputil.ReverseProxy {
 			}
 		}
 
-		// Validate that the node actually exists in the network
-		// TODO:
-
 		// Only proxy http for now
 		req.URL.Scheme = "http"
 
-		req.URL.Host = node
+		req.URL.Host = fmt.Sprintf("%s:%s", node, port)
 	}
 
 	return &httputil.ReverseProxy{Director: director}

--- a/services/docker.go
+++ b/services/docker.go
@@ -52,6 +52,17 @@ func CreateNetwork(name string) error {
 
 	return nil
 }
+func ConnectNetwork(containerId, networkId string) error {
+	err := c.NetworkConnect(context.Background(), networkId, containerId, &network.EndpointSettings{})
+
+	if err != nil {
+		log.Printf("Connection container to network err [%s]\n", err)
+
+		return err
+	}
+
+	return nil
+}
 
 func DeleteNetwork(id string) error {
 	err := c.NetworkRemove(context.Background(), id)

--- a/services/session.go
+++ b/services/session.go
@@ -109,6 +109,12 @@ func NewSession() (*Session, error) {
 		return nil, err
 	}
 
+	// Connect PWD daemon to the new network
+	if err := ConnectNetwork("pwd", s.Id); err != nil {
+		log.Println("ERROR NETWORKING")
+		return nil, err
+	}
+
 	// We store sessions as soon as we create one so we don't delete new sessions on an api restart
 	if err := saveSessionsToDisk(); err != nil {
 		return nil, err

--- a/services/session.go
+++ b/services/session.go
@@ -108,12 +108,14 @@ func NewSession() (*Session, error) {
 		log.Println("ERROR NETWORKING")
 		return nil, err
 	}
+	log.Printf("Network [%s] created for session [%s]\n", s.Id, s.Id)
 
 	// Connect PWD daemon to the new network
 	if err := ConnectNetwork("pwd", s.Id); err != nil {
 		log.Println("ERROR NETWORKING")
 		return nil, err
 	}
+	log.Printf("Connected pwd to network [%s]\n", s.Id)
 
 	// We store sessions as soon as we create one so we don't delete new sessions on an api restart
 	if err := saveSessionsToDisk(); err != nil {


### PR DESCRIPTION
It works by using the `Host` of the request. When it receives something in
the form of: `<node>.<session>.play-with-docker.com` it does a reverse
proxy http request to `node`, validating that the `node` actually belongs
to the `session`.

If the node has a prefix `ip` and continues with a valid IP address
where the dots where replaces by underscores (like `ip10_0_0_1`) then it
will remove the `ip` prefix and and replace the underscores by dots, and
assume it is an ip address.

**There is an important assumption that the daemon container is called `pwd`**