### PR TITLE
Fix race conditions when initially resizing terminal

### DIFF
--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -204,9 +204,11 @@
           });
 
           term.open(terminalContainer);
-          term.fit();
-
-          $scope.resize(term.proposeGeometry());
+          
+          // Set geometry during the next tick, to avoid race conditions.
+          setTimeout(function() {
+              $scope.resize(term.proposeGeometry());
+          }, 4);
 
           term.on('data', function(d) {
             $scope.socket.emit('terminal in', instance.name, d);


### PR DESCRIPTION
Race conditions could happen if the Terminal container did not have the correct size during initialization.

Signed-off-by: Antonis Kalipetis <akalipetis@gmail.com>