### PR TITLE
Enable use of override for session timeout in hours, fix captcha bypass bug.

### DIFF
--- a/api.go
+++ b/api.go
@@ -5,24 +5,20 @@ import (
 	"net/http"
 	"os"
 
+	"flag"
+	"strconv"
+
 	"github.com/franela/play-with-docker/handlers"
 	"github.com/franela/play-with-docker/services"
 	"github.com/franela/play-with-docker/templates"
 	"github.com/gorilla/mux"
 	"github.com/urfave/negroni"
-	"flag"
-	"strconv"
 )
 
 func main() {
 	var portNumber int
 	flag.IntVar(&portNumber, "port", 3000, "Give a TCP port to run the application")
 	flag.Parse()
-
-	welcome, tmplErr := templates.GetWelcomeTemplate()
-	if tmplErr != nil {
-		log.Fatal(tmplErr)
-	}
 
 	bypassCaptcha := len(os.Getenv("GOOGLE_RECAPTCHA_DISABLED")) > 0
 
@@ -79,7 +75,7 @@ func main() {
 	n := negroni.Classic()
 	n.UseHandler(r)
 
-	log.Println("Listening on port "+ strconv.Itoa(portNumber))
+	log.Println("Listening on port " + strconv.Itoa(portNumber))
 	log.Fatal(http.ListenAndServe("0.0.0.0:"+strconv.Itoa(portNumber), n))
 
 }

--- a/api.go
+++ b/api.go
@@ -15,7 +15,6 @@ import (
 )
 
 func main() {
-
 	var portNumber int
 	flag.IntVar(&portNumber, "port", 3000, "Give a TCP port to run the application")
 	flag.Parse()
@@ -25,8 +24,9 @@ func main() {
 		log.Fatal(tmplErr)
 	}
 
-	server := services.CreateWSServer()
+	bypassCaptcha := len(os.Getenv("GOOGLE_RECAPTCHA_DISABLED")) > 0
 
+	server := services.CreateWSServer()
 	server.On("connection", handlers.WS)
 	server.On("error", handlers.WSError)
 
@@ -45,9 +45,19 @@ func main() {
 	r.StrictSlash(false)
 
 	r.HandleFunc("/ping", http.HandlerFunc(handlers.Ping)).Methods("GET")
+
 	r.HandleFunc("/", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		rw.Write(welcome)
+		if bypassCaptcha {
+			http.ServeFile(rw, r, "./www/bypass.html")
+		} else {
+			welcome, tmplErr := templates.GetWelcomeTemplate()
+			if tmplErr != nil {
+				log.Fatal(tmplErr)
+			}
+			rw.Write(welcome)
+		}
 	})).Methods("GET")
+
 	r.HandleFunc("/", http.HandlerFunc(handlers.NewSession)).Methods("POST")
 
 	r.HandleFunc("/sessions/{sessionId}", http.HandlerFunc(handlers.GetSession)).Methods("GET")
@@ -57,6 +67,7 @@ func main() {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./www/index.html")
 	})
+
 	r.HandleFunc("/p/{sessionId}", h).Methods("GET")
 	r.PathPrefix("/assets").Handler(http.FileServer(http.Dir("./www")))
 	r.HandleFunc("/robots.txt", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {

--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -3,6 +3,14 @@
 
 	var app = angular.module('DockerPlay', ['ngMaterial']);
 
+    // Automatically redirects user to a new session when bypassing captcha.
+    // Controller keeps code/logic separate from the HTML
+    app.controller("BypassController", ['$scope', '$log', '$http', '$location', '$timeout', '$mdDialog', '$window', function($scope, $log, $http, $location, $timeout, $mdDialog, $window) {
+        setTimeout(function() {
+            var el = document.querySelector("#submit");
+            el.click();
+        }, 500);
+    }]);
 
 	app.controller('PlayController', ['$scope', '$log', '$http', '$location', '$timeout', '$mdDialog', '$window', function($scope, $log, $http, $location, $timeout, $mdDialog, $window) {
 		$scope.sessionId = window.location.pathname.replace('/p/', '');

--- a/www/bypass.html
+++ b/www/bypass.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html ng-app="DockerPlay" ng-controller="BypassController">
+    <head>
+        <title>Docker Playground</title>
+	    <link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.css">
+        <link rel="stylesheet" href="/assets/style.css" />
+    </head>
+    <body class="welcome">
+        <div>
+            <h1>Welcome!</h1>
+            <h2>We're bypassing the Captcha and redirecting you now..</h2>
+            <form id="welcomeFormBypass" method="POST" action="/">
+                <button id="submit" type="submit">Start Session</button>
+            </form>
+        </div>
+    </body>
+
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-aria.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-messages.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.js"></script>
+
+    <script src="/assets/app.js"></script>
+</html>

--- a/www/bypass.html
+++ b/www/bypass.html
@@ -15,11 +15,11 @@
         </div>
     </body>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-aria.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-messages.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-aria.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-messages.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.js"></script>
 
     <script src="/assets/app.js"></script>
 </html>

--- a/www/index.html
+++ b/www/index.html
@@ -8,6 +8,7 @@
         <link rel="stylesheet" href="/assets/style.css" />
     </head>
     <body>
+
         <div layout="column" style="height:100%;" ng-cloak>
             <section id="sessionEnd" layout="row" flex ng-if="!isAlive">
               <md-content flex layout-padding ng-if="!instances.length">
@@ -19,10 +20,12 @@
                 <div flex></div>
               </md-content>
             </section>
+
             <section ng-if="!connected" class="disconnected" layout="row" layout-align="center center">
                 <h1 class="md-headline">No connection to server. Reconnecting...</h1>
                 <md-progress-circular class="md-hue-2" md-diameter="20px"></md-progress-circular>
             </section>
+
             <section id="popupContainer" layout="row" flex ng-if="isAlive">
               <md-sidenav
                   class="md-sidenav-left"
@@ -36,9 +39,7 @@
                   <h1 class="md-toolbar-tools">Instances</h1>
                 </md-toolbar>
                 <md-content layout-padding>
-                  <md-button ng-click="newInstance()" class="md-primary">
-                + Add new instance
-                  </md-button>
+                  <md-button ng-click="newInstance()" class="md-primary">+ Add new instance</md-button>
               <md-list>
                 <md-list-item ng-switch on="instance.isManager" class="md-3-line" ng-repeat="instance in instances" ng-click="showInstance(instance)" ng-class="instance.name == selectedInstance.name ? 'selected' : false">
                     <md-icon ng-switch-when="true" style="color: blue" md-svg-icon="person"></md-icon>
@@ -52,12 +53,8 @@
               </md-sidenav>
               <md-content flex layout-padding ng-if="!instances.length">
                 <div layout="column" layout-align="top center">
-                  <p>
-              Add instances to your playground.
-                  </p>
-                  <p>
-              <strong>Sessions and all their instances are deleted after 4 hours.</strong>
-                  </p>
+                  <p>Add instances to your playground.</p>
+                  <p><strong>Sessions and all their instances are deleted after {{ttl}} hours.</strong></p>
                 </div>
 
                 <div flex></div>
@@ -92,17 +89,13 @@
                       </md-card-content>
                   </md-card>
               </md-content>
-
-
             </section>
-
         </div>
 
-        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.min.js"></script>
-        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.min.js"></script>
-        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-aria.min.js"></script>
-        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-messages.min.js"></script>
-        <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.js"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.min.js"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.min.js"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-aria.min.js"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-messages.min.js"></script>
         <script src="https://cdn.socket.io/socket.io-1.3.7.js"></script>
         <script src="/assets/app.js"></script>
         <script src="/assets/xterm.js"></script>

--- a/www/index.html
+++ b/www/index.html
@@ -92,10 +92,10 @@
             </section>
         </div>
 
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.min.js"></script>
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.min.js"></script>
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-aria.min.js"></script>
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-messages.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-aria.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-messages.min.js"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.js"></script>
 
         <script src="https://cdn.socket.io/socket.io-1.3.7.js"></script>

--- a/www/index.html
+++ b/www/index.html
@@ -96,6 +96,8 @@
         <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.min.js"></script>
         <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-aria.min.js"></script>
         <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-messages.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.js"></script>
+
         <script src="https://cdn.socket.io/socket.io-1.3.7.js"></script>
         <script src="/assets/app.js"></script>
         <script src="/assets/xterm.js"></script>

--- a/www/welcome.html
+++ b/www/welcome.html
@@ -1,6 +1,6 @@
 {{define "GOOGLE_RECAPTCHA_SITE_KEY"}}
 <!doctype html>
-<html ng-app="DockerPlay" ng-controller="PlayController">
+<html>
     <head>
         <title>Docker Playground</title>
 	    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.css">


### PR DESCRIPTION
- Enable use of override for session timeout. This is more useful than having to hard-code and rebuild the code for the previous 4 hour limit. Just set environmental variable and start the app.
- Future work may involve breaking down into minutes, but this is a good minimum delivery to provide value to end-user/developer.
    
- Fixes bug in Captcha code by introducing new landing page. This is not a new go template, it's a separate HTML file because SRP - single reponsibility principle. Happy for this to be refacted after merging commit.
    
- Fix for including Docker 1.12 override has been removed for later PR.