### PR TITLE
Periodic tasks refactor

### DIFF
--- a/services/broadcast_info_task.go
+++ b/services/broadcast_info_task.go
@@ -1,0 +1,8 @@
+package services
+
+type broadcastInfoTask struct {
+}
+
+func (c *broadcastInfoTask) Run(i *Instance) {
+	wsServer.BroadcastTo(i.session.Id, "instance stats", i.Name, i.Mem, i.Cpu, i.IsManager)
+}

--- a/services/check_swarm_status_task.go
+++ b/services/check_swarm_status_task.go
@@ -1,0 +1,15 @@
+package services
+
+import "github.com/docker/docker/api/types/swarm"
+
+type checkSwarmStatusTask struct {
+}
+
+func (c checkSwarmStatusTask) Run(i *Instance) {
+	if info, err := GetDaemonInfo(i); err == nil {
+		if info.Swarm.LocalNodeState != swarm.LocalNodeStateInactive && info.Swarm.LocalNodeState != swarm.LocalNodeStateLocked {
+			i.IsManager = &info.Swarm.ControlAvailable
+		}
+	}
+
+}

--- a/services/collect_stats_task.go
+++ b/services/collect_stats_task.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/docker/docker/api/types"
+	units "github.com/docker/go-units"
+)
+
+type collectStatsTask struct {
+	mem        float64
+	memLimit   float64
+	memPercent float64
+	v          *types.StatsJSON
+
+	cpuPercent     float64
+	previousCPU    uint64
+	previousSystem uint64
+}
+
+func (c *collectStatsTask) Run(i *Instance) {
+	reader, err := GetContainerStats(i.Name)
+	if err != nil {
+		log.Println("Error while trying to collect instance stats", err)
+		return
+	}
+	dec := json.NewDecoder(reader)
+	e := dec.Decode(&c.v)
+	if e != nil {
+		log.Println("Error while trying to collect instance stats", e)
+		return
+	}
+	// Memory
+	if c.v.MemoryStats.Limit != 0 {
+		c.memPercent = float64(c.v.MemoryStats.Usage) / float64(c.v.MemoryStats.Limit) * 100.0
+	}
+	c.mem = float64(c.v.MemoryStats.Usage)
+	c.memLimit = float64(c.v.MemoryStats.Limit)
+
+	i.Mem = fmt.Sprintf("%.2f%% (%s / %s)", c.memPercent, units.BytesSize(c.mem), units.BytesSize(c.memLimit))
+
+	// cpu
+	c.previousCPU = c.v.PreCPUStats.CPUUsage.TotalUsage
+	c.previousSystem = c.v.PreCPUStats.SystemUsage
+	c.cpuPercent = calculateCPUPercentUnix(c.previousCPU, c.previousSystem, c.v)
+	i.Cpu = fmt.Sprintf("%.2f%%", c.cpuPercent)
+}
+
+func calculateCPUPercentUnix(previousCPU, previousSystem uint64, v *types.StatsJSON) float64 {
+	var (
+		cpuPercent = 0.0
+		// calculate the change for the cpu usage of the container in between readings
+		cpuDelta = float64(v.CPUStats.CPUUsage.TotalUsage) - float64(previousCPU)
+		// calculate the change for the entire system between readings
+		systemDelta = float64(v.CPUStats.SystemUsage) - float64(previousSystem)
+	)
+
+	if systemDelta > 0.0 && cpuDelta > 0.0 {
+		cpuPercent = (cpuDelta / systemDelta) * float64(len(v.CPUStats.CPUUsage.PercpuUsage)) * 100.0
+	}
+	return cpuPercent
+}

--- a/services/docker.go
+++ b/services/docker.go
@@ -41,6 +41,9 @@ func GetContainerInfo(id string) (types.ContainerJSON, error) {
 }
 
 func GetDaemonInfo(i *Instance) (types.Info, error) {
+	if i.dockerClient == nil {
+		return types.Info{}, fmt.Errorf("Docker client for DinD (%s) is not ready", i.IP)
+	}
 	return i.dockerClient.Info(context.Background())
 }
 

--- a/services/docker.go
+++ b/services/docker.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
-	"net/http"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -34,7 +31,7 @@ func init() {
 }
 
 func GetContainerStats(id string) (io.ReadCloser, error) {
-	stats, err := c.ContainerStats(context.Background(), id, true)
+	stats, err := c.ContainerStats(context.Background(), id, false)
 
 	return stats.Body, err
 }
@@ -43,20 +40,8 @@ func GetContainerInfo(id string) (types.ContainerJSON, error) {
 	return c.ContainerInspect(context.Background(), id)
 }
 
-func GetDaemonInfo(host string) (types.Info, error) {
-	transport := &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout:   1 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext}
-	cli := &http.Client{
-		Transport: transport,
-	}
-	c, err := client.NewClient(host, client.DefaultVersion, cli, nil)
-	if err != nil {
-		return types.Info{}, err
-	}
-	return c.Info(context.Background())
+func GetDaemonInfo(i *Instance) (types.Info, error) {
+	return i.dockerClient.Info(context.Background())
 }
 
 func CreateNetwork(name string) error {

--- a/services/session.go
+++ b/services/session.go
@@ -89,7 +89,7 @@ func (s *Session) SchedulePeriodicTasks() {
 					for _, t := range periodicTasks {
 						t.Run(i)
 					}
-					wg.Done()
+					defer wg.Done()
 				}()
 			}
 			wg.Wait()

--- a/services/session.go
+++ b/services/session.go
@@ -86,10 +86,10 @@ func (s *Session) SchedulePeriodicTasks() {
 					}
 				}
 				go func() {
+					defer wg.Done()
 					for _, t := range periodicTasks {
 						t.Run(i)
 					}
-					defer wg.Done()
 				}()
 			}
 			wg.Wait()

--- a/services/session.go
+++ b/services/session.go
@@ -2,13 +2,17 @@ package services
 
 import (
 	"encoding/gob"
+	"fmt"
 	"log"
 	"math"
+	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/docker/docker/client"
 	"github.com/googollee/go-socket.io"
 	"github.com/twinj/uuid"
 )
@@ -22,6 +26,8 @@ type Session struct {
 	clients   []*Client            `json:"-"`
 	CreatedAt time.Time            `json:"created_at"`
 	ExpiresAt time.Time            `json:"expires_at"`
+	scheduled bool                 `json:"-"`
+	ticker    *time.Ticker         `json:"-"`
 }
 
 func (s *Session) Lock() {
@@ -48,6 +54,49 @@ func (s *Session) AddNewClient(c *Client) {
 	s.clients = append(s.clients, c)
 }
 
+func (s *Session) SchedulePeriodicTasks() {
+	if s.scheduled {
+		return
+	}
+
+	go func() {
+		s.scheduled = true
+
+		s.ticker = time.NewTicker(1 * time.Second)
+		for range s.ticker.C {
+			var wg = sync.WaitGroup{}
+			wg.Add(len(s.Instances))
+			for _, i := range s.Instances {
+				if i.dockerClient == nil {
+					// Need to create client to the DinD docker daemon
+
+					transport := &http.Transport{
+						DialContext: (&net.Dialer{
+							Timeout:   1 * time.Second,
+							KeepAlive: 30 * time.Second,
+						}).DialContext}
+					cli := &http.Client{
+						Transport: transport,
+					}
+					c, err := client.NewClient(fmt.Sprintf("http://%s:2375", i.IP), client.DefaultVersion, cli, nil)
+					if err != nil {
+						log.Println("Could not connect to DinD docker daemon", err)
+					} else {
+						i.dockerClient = c
+					}
+				}
+				go func() {
+					for _, t := range periodicTasks {
+						t.Run(i)
+					}
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+		}
+	}()
+}
+
 var sessions map[string]*Session
 
 func init() {
@@ -72,6 +121,8 @@ func CloseSessionAfter(s *Session, d time.Duration) {
 func CloseSession(s *Session) error {
 	s.rw.Lock()
 	defer s.rw.Unlock()
+
+	s.ticker.Stop()
 	wsServer.BroadcastTo(s.Id, "session end")
 	log.Printf("Starting clean up of session [%s]\n", s.Id)
 	for _, i := range s.Instances {
@@ -88,6 +139,11 @@ func CloseSession(s *Session) error {
 		return err
 	}
 	delete(sessions, s.Id)
+
+	// We store sessions as soon as we delete one
+	if err := saveSessionsToDisk(); err != nil {
+		return err
+	}
 	log.Printf("Cleaned up session [%s]\n", s.Id)
 	return nil
 }
@@ -135,6 +191,9 @@ func NewSession() (*Session, error) {
 	}
 	log.Printf("Connected pwd to network [%s]\n", s.Id)
 
+	// Schedule peridic tasks execution
+	s.SchedulePeriodicTasks()
+
 	// We store sessions as soon as we create one so we don't delete new sessions on an api restart
 	if err := saveSessionsToDisk(); err != nil {
 		return nil, err
@@ -175,8 +234,11 @@ func LoadSessionsFromDisk() error {
 			for _, i := range s.Instances {
 				// wire the session back to the instance
 				i.session = s
-				go i.CollectStats()
+
 			}
+
+			// Schedule peridic tasks execution
+			s.SchedulePeriodicTasks()
 		}
 	}
 	file.Close()

--- a/services/task.go
+++ b/services/task.go
@@ -1,0 +1,11 @@
+package services
+
+type periodicTask interface {
+	Run(i *Instance)
+}
+
+var periodicTasks []periodicTask
+
+func init() {
+	periodicTasks = append(periodicTasks, &collectStatsTask{}, &checkSwarmStatusTask{}, &broadcastInfoTask{})
+}


### PR DESCRIPTION
Once every second the session run a list of periodic tasks on every instance concurrently. We use these tasks to do things like:
- Collect mem and cpu stats
- Check if instance is part of a swarm cluster
- Broadcast information to connected clients