### PR TITLE
Remove pointer in struct method to avoid concurrent modifications to the same value

### DIFF
--- a/services/collect_stats_task.go
+++ b/services/collect_stats_task.go
@@ -20,7 +20,7 @@ type collectStatsTask struct {
 	previousSystem uint64
 }
 
-func (c *collectStatsTask) Run(i *Instance) {
+func (c collectStatsTask) Run(i *Instance) {
 	reader, err := GetContainerStats(i.Name)
 	if err != nil {
 		log.Println("Error while trying to collect instance stats", err)


### PR DESCRIPTION
Fixes panic when trying to monitor multiple instances.

@xetorthio :bell: 