### PR TITLE
Added keyboard shortcut (Cmd+K) to clear terminal

### DIFF
--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -245,6 +245,14 @@
                 }
             });
 
+            term.attachCustomKeydownHandler(function(e) {
+                // Cmd + K
+                if (e.metaKey && e.keyCode == 75) {
+                    term.clear();
+                    return false;
+                }
+            });
+
             term.open(terminalContainer);
 
             // Set geometry during the next tick, to avoid race conditions.


### PR DESCRIPTION
I'm so use to using a keyboard shortcut to clear the terminal.  Figured as often as I'm using PWD for presentations, it would be nice to have that here as well.  

Currently captures Cmd+K for Macs.  Not sure if there's an equivalent shortcut for Windows-based environments.  This will do Windows+K, which I'm guessing wouldn't be it.