### PR TITLE
Add jq (JSON swiss-army knife) to DinD image

### DIFF
--- a/Dockerfile.dind
+++ b/Dockerfile.dind
@@ -1,6 +1,6 @@
 FROM docker:17.03.0-ce-dind
 
-RUN apk add --no-cache git tmux py2-pip apache2-utils vim build-base gettext-dev curl bash-completion bash util-linux
+RUN apk add --no-cache git tmux py2-pip apache2-utils vim build-base gettext-dev curl bash-completion bash util-linux jq
 
 ENV COMPOSE_VERSION=1.11.1
 # Install Compose and Machine


### PR DESCRIPTION
`jq` is super useful to parse the output of the Docker CLI or even
to tinker with JSON REST APIs. I propose its inclusion to the image :-)