### PR TITLE
Automatically restart dockerd if it exits or is killed

### DIFF
--- a/Dockerfile.dind
+++ b/Dockerfile.dind
@@ -24,8 +24,8 @@ RUN mkdir /etc/bash_completion.d && curl https://raw.githubusercontent.com/docke
 RUN rm /sbin/modprobe && echo '#!/bin/true' >/sbin/modprobe && chmod +x /sbin/modprobe
 
 # Install a nice vimrc file and prompt (by soulshake)
-COPY ["docker-prompt","/usr/local/bin/"]
-COPY [".vimrc",".profile", ".inputrc", ".gitconfig", "./root/"]
+COPY ["docker-prompt", "rc.dockerd", "/usr/local/bin/"]
+COPY [".vimrc", ".profile", ".inputrc", ".gitconfig", "./root/"]
 COPY ["daemon.json", "/etc/docker/"]
 
 ARG docker_storage_driver=overlay2
@@ -41,6 +41,6 @@ CMD cat /etc/hosts >/etc/hosts.bak && \
     sed -i "s/\DOCKER_STORAGE_DRIVER/$DOCKER_STORAGE_DRIVER/" /etc/docker/daemon.json && \
     sed -i "s/\PWD_IP_ADDRESS/$PWD_IP_ADDRESS/" /etc/docker/daemon.json && \
     umount /var/lib/docker && \
-    dockerd &>/docker.log & \
+    while sleep 1 ; do [ -x /usr/local/bin/rc.dockerd ] && /usr/local/bin/rc.dockerd; done & \
     while true ; do script -q -c "/bin/bash -l" /dev/null ; done
 # ... and then put a shell in the foreground, restarting it if it exits

--- a/rc.dockerd
+++ b/rc.dockerd
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# This script gets automatically executed when the DinD container
+# starts. If this script exits, it will be automatically restarted.
+
+# You can disable that script by renaming it or removing its
+# executable bit. If this script comes back, the DinD "init system"
+# will pick it up and execute it again.
+
+# First, let's redirect stdout and stderr to a log file.
+exec >>/docker.log 2>>/docker.log
+
+# If you want to change Docker's start-up flags, you can do it here!
+dockerd
+
+# If dockerd exits (or is killed), let's log the status.
+echo "dockerd: exit status: $?"


### PR DESCRIPTION
This patch will automatically restart dockerd if it crashes,
exits, or is killed. At the same time, it will allow to
tweak dockerd command-line flags by tweaking the file
/usr/local/bin/rc.dockerd (that file can also be renamed
to disable the auto-restart behavior).

I'm not sure at 100% that we need this. I feel like it
could be useful, but adding a pseudo init system to
the DinD image also feels clunky. On the other hands,
it mimics what people would do on a "real" system.

I'm open to discussion of course!