### PR TITLE
Added ability to specify new instance image in UI

### DIFF
--- a/api.go
+++ b/api.go
@@ -68,6 +68,7 @@ func main() {
 	r.Host(`{subdomain:.*}{node:pwd[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}}-{port:[0-9]*}.{tld:.*}`).Handler(tcpHandler)
 	r.Host(`{subdomain:.*}{node:pwd[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}}.{tld:.*}`).Handler(tcpHandler)
 	r.HandleFunc("/ping", handlers.Ping).Methods("GET")
+	corsRouter.HandleFunc("/instances/images", handlers.GetInstanceImages).Methods("GET")
 	corsRouter.HandleFunc("/sessions/{sessionId}", handlers.GetSession).Methods("GET")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances", handlers.NewInstance).Methods("POST")
 	corsRouter.HandleFunc("/sessions/{sessionId}/instances/{instanceName}", handlers.DeleteInstance).Methods("DELETE")
@@ -218,3 +219,5 @@ func handleDnsRequest(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 }
+
+

--- a/handlers/get_instance_images.go
+++ b/handlers/get_instance_images.go
@@ -1,0 +1,14 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/franela/play-with-docker/services"
+)
+
+func GetInstanceImages(rw http.ResponseWriter, req *http.Request) {
+	instanceImages := services.InstanceImages()
+	json.NewEncoder(rw).Encode(instanceImages)
+}
+

--- a/services/instance_images.go
+++ b/services/instance_images.go
@@ -1,0 +1,10 @@
+package services
+
+func InstanceImages() ([]string) {
+
+	return []string {
+		"franela/dind:overlay2", 
+		"franela/dind-dev:overlay2",
+	}
+
+}

--- a/www/index.html
+++ b/www/index.html
@@ -149,6 +149,18 @@
                             </div>
                         </div>
                     </div>
+                    <div layout="row">
+                        <div flex="50">
+                            <md-input-container class="md-block" flex-gt-sm>
+                                <label>Instance Image</label>
+                                <md-select ng-model="$ctrl.currentDesiredInstanceImage" ng-model-options="{getterSetter: true}" placeholder="New Instance Image">
+                                    <md-option ng-repeat="image in $ctrl.instanceImages" value="{{image}}">
+                                        {{ image }}
+                                    </md-option>
+                                </md-select>
+                            </md-input-container>
+                        </div>
+                    </div>
                 </div>
                 </md-dialog-content>
 
@@ -187,3 +199,4 @@
         </script>
     </body>
 </html>
+


### PR DESCRIPTION
First time writing/contributing some Go code! 😎 

- Created new API endpoint that specifies available instance images
  - Default image used in UI is first image in array
  - Updating array will update choices in UI
- Added setting to UI preferences screen

I didn't add a validation check to ensure a requested image is one actually supported (checking those provided by `services/InstanceImages`. But, feel free to do so.